### PR TITLE
Add cursor pointer to clickable elements

### DIFF
--- a/app/webroot/css/style.css
+++ b/app/webroot/css/style.css
@@ -252,6 +252,10 @@ body, body.modal-open {
 /***
  * Generics classes
  *********************************/
+ tr[data-id]{
+ 	cursor: pointer;
+ }
+ 
 .track-number{
     width: 25px;
     line-height:1;


### PR DESCRIPTION
First time I used Sonorezh, the cursor on clickable music titles elements was kind of disturbing. I fixed it by adding a little CSS property. A cleaner way to do it were to be able to add a specific class on music titles tables, but I don't know if it is in your development process.