### PR TITLE
ignore tmp/cache and tmp/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /app/Config/database.php
 /app/Config/email.php
 /app/tmp/tests
+/app/tmp/cache
+/app/tmp/logs
 /lib/Cake/Console/Templates/skel/tmp/
 /plugins
 /vendors


### PR DESCRIPTION
These directories should not be tracked and make `git status` output hard to read:

```
# Untracked files
#   (use "git add <file>..." to include in what will be committed)
#
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_list
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_playlist_memberships
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_playlists
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_settings
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_songs
#	app/tmp/cache/models/myapp_cake_model_default_sonerezh_users
#	app/tmp/cache/persistent/myapp_cake_core_cake_console_en-us
#	app/tmp/cache/persistent/myapp_cake_core_cake_dev_en-us
#	app/tmp/cache/persistent/myapp_cake_core_cake_en-us
#	app/tmp/cache/persistent/myapp_cake_core_cake_fr
#	app/tmp/cache/persistent/myapp_cake_core_default_en-us
#	app/tmp/cache/persistent/myapp_cake_core_default_fr
#	app/tmp/cache/persistent/myapp_cake_core_file_map
#	app/tmp/cache/persistent/myapp_cake_core_method_cache
#	app/tmp/logs/debug.log
#	app/tmp/logs/error.log
```
