### PR TITLE
track_number need to be converted to integer

### DIFF
--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -47,7 +47,7 @@ class SongsController extends AppController{
             }
 
             if (isset($songInfo['comments']['track_number']) && intval($songInfo['comments']['track_number'][0])) {
-                $newSong['track_number'] = $songInfo['comments']['track_number'][0];
+                $newSong['track_number'] = intval($songInfo['comments']['track_number'][0]);
             }
 
             if (isset($songInfo['playtime_string'])) {


### PR DESCRIPTION
Sometimes $songInfo['comments']['track_number'] not contains an integer (for example "1/19"), you need to convert it.
