### PR TITLE
Fix incorect name field for password confirmation for installation

### DIFF
--- a/app/Controller/InstallersController.php
+++ b/app/Controller/InstallersController.php
@@ -107,7 +107,7 @@ class InstallersController extends AppController {
             $this->request->data['Setting']['enable_auto_conv'] = $libavtools;
 
 
-            if($this->request->data['User']['password'] != $this->request->data['User']['password_confirmation']){
+            if($this->request->data['User']['password'] != $this->request->data['User']['confirm_password']){
                 $user = false;
                 $this->User->validationErrors["password"][] = __("Passwords do not match.");
             }else{

--- a/app/View/Installers/index.ctp
+++ b/app/View/Installers/index.ctp
@@ -97,7 +97,7 @@
         <?php
         echo $this->Form->input('User.email', array('placeholder' => 'john.doe@sonerezh.bzh'));
         echo $this->Form->input('User.password', array('placeholder' => __('Password'), 'label' => array('text' => __('Password (twice)'), 'class' => 'col-sm-3 control-label')));
-        echo $this->Form->input('User.password_confirmation', array('placeholder' => __('Confirm your password'), 'type' => 'password', 'label' => array('text' => '', 'class' => 'col-sm-3 control-label')));
+        echo $this->Form->input('User.confirm_password', array('placeholder' => __('Confirm your password'), 'type' => 'password', 'label' => array('text' => '', 'class' => 'col-sm-3 control-label')));
         echo $this->Form->input('Setting.rootpath', array('placeholder' => '/home/jdoe/Music', 'label' => array('text' => 'Music folder', 'class' => 'col-sm-3 control-label'), 'after' => '<p class="help-block">Current App folder is: '.APP.'</p>'));
 
         if ($gd && $is_config_writable && $is_core_writable) {


### PR DESCRIPTION
Due to the " Fix #48" an password verification has added.

He use "confirm_password"  instead of "password_confirmation"

My fix rename the data label from "password_confirmation" to
"confirm_password"