### PR TITLE
Fix Ajax request to GET instead of JSON

### DIFF
--- a/app/webroot/js/jquery.scroll.js
+++ b/app/webroot/js/jquery.scroll.js
@@ -26,7 +26,8 @@
                 $('#scroll-loader').show();
                 $.ajax({
                     url: link + (link.indexOf("?ajax=true") == -1 ? (link.indexOf("?") == -1) ? "?ajax=true" : "&ajax=true" : ""),
-                    type: 'json',
+                    type: 'get',
+                    dataType : 'json',
                     success: function(data){
                         var html = data[2].html;
                         var nextLink = $(html).find(settings.nextSelector).attr('href');


### PR DESCRIPTION
In Raspbian (Raspberry pi) with Apache 2.2, JSON http request method are not recognized, also infinite scroll doesn't work... By change to GET request with datatype json this will fix it.