### PR TITLE
Fix language typos.

### DIFF
--- a/app/Controller/InstallersController.php
+++ b/app/Controller/InstallersController.php
@@ -77,7 +77,7 @@ class InstallersController extends AppController {
                     }
 
                 } else {
-                    $requirements[$driver] = array('label' => 'warning', 'message' => $driver . ' ' . __('is required if you wan to use Sonerezh with ') . $driver);
+                    $requirements[$driver] = array('label' => 'warning', 'message' => $driver . ' ' . __('is required if you want to use Sonerezh with ') . $driver);
                 }
             }
         }

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -42,7 +42,7 @@ msgid "driver is installed."
 msgstr ""
 
 #: Controller/InstallersController.php:80
-msgid "is required if you wan to use Sonerezh with "
+msgid "is required if you want to use Sonerezh with "
 msgstr ""
 
 #: Controller/InstallersController.php:88;97

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -58,8 +58,8 @@ msgid "driver is installed."
 msgstr "pilote est installé."
 
 #: Controller/InstallersController.php:80
-msgid "is required if you wan to use Sonerezh with "
-msgstr "est requis si vous souhaitez utiliser Sonerezh avec"
+msgid "is required if you want to use Sonerezh with "
+msgstr "est requis si vous souhaitez utiliser Sonerezh avec "
 
 #: Controller/InstallersController.php:88;97
 msgid "is writable"


### PR DESCRIPTION
Same very simple fix: "wan" -> "want" and a missing space in the end of a french translation, but based on the development branch this time.