### PR TITLE
Database backend and song conversion fixes

### DIFF
--- a/app/Config/Schema/sonerezh_pgsql.php
+++ b/app/Config/Schema/sonerezh_pgsql.php
@@ -64,7 +64,7 @@ class SonerezhPgsqlSchema extends CakeSchema {
 		'path' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 1024),
 		'cover' => array('type' => 'string', 'null' => true, 'default' => null),
 		'playtime' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 9),
-		'track_number' => array('type' => 'integer', 'null' => true, 'default' => null),
+		'track_number' => array('type' => 'string', 'null' => true, 'default' => null),
 		'year' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'disc' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 7),
 		'band' => array('type' => 'string', 'null' => true, 'default' => null),

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -572,11 +572,11 @@ class SongsController extends AppController {
                 if ($settings['Setting']['convert_to'] == 'mp3') {
                     $path = TMP.date('YmdHis').".mp3";
                     $song['Song']['path'] = $path;
-                    passthru($avconv . " -i " . escapeshellarg($song['Song']['source_path']) . " -threads 4 -c:a libmp3lame -b:a " . escapeshellarg($bitrate . 'k') . " " . escapeshellarg($path) . " 2>&1");
+                    passthru($avconv . " -i " . escapeshellarg($song['Song']['source_path']) . " -threads 4 -c:a libmp3lame -b:a " . escapeshellarg($bitrate . 'k') . " " . escapeshellarg($path) . " 2>/dev/null");
                 } elseif ($settings['Setting']['convert_to'] == 'ogg') {
                     $path = TMP.date('YmdHis').".ogg";
                     $song['Song']['path'] = $path;
-                    passthru($avconv . " -i " . escapeshellarg($song['Song']['source_path']) . " -threads 4 -c:a libvorbis -q:a " . escapeshellarg($bitrate) . " " . escapeshellarg($path) . " 2>&1");
+                    passthru($avconv . " -i " . escapeshellarg($song['Song']['source_path']) . " -threads 4 -c:a libvorbis -q:a " . escapeshellarg($bitrate) . " " . escapeshellarg($path) . " 2>/dev/null");
                 }
             } elseif (empty($song['Song']['path'])) {
                 $song['Song']['path'] = $song['Song']['source_path'];


### PR DESCRIPTION
Hi I made two fixes in the app.

The one related to the sql backend is about postgresql getting stuck while importing songs with letters or other unicode characters in place of numbers in the track_number tag.

The other fix redirects the stderr output of ffmpeg/avconv converting the non-mp3 songs to /dev/null, avoiding mixing it with song data being sent to the browser. With this fix songs that are not in the cache will start playing as soon as the conversion ends, instead of getting the player stuck even if the conversion is over.

cheers,
seppia