### PR TITLE
Parse and display the comment tag in mp3 files

### DIFF
--- a/app/Config/Schema/sonerezh_mysql.php
+++ b/app/Config/Schema/sonerezh_mysql.php
@@ -69,6 +69,7 @@ class SonerezhMysqlSchema extends CakeSchema {
 		'disc' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 7, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'band' => array('type' => 'string', 'null' => true, 'default' => null, 'key' => 'index', 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'genre' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'comment' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'modified' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array(

--- a/app/Config/Schema/sonerezh_pgsql.php
+++ b/app/Config/Schema/sonerezh_pgsql.php
@@ -69,6 +69,7 @@ class SonerezhPgsqlSchema extends CakeSchema {
 		'disc' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 7),
 		'band' => array('type' => 'string', 'null' => true, 'default' => null),
 		'genre' => array('type' => 'string', 'null' => true, 'default' => null),
+		'comment' => array('type' => 'string', 'null' => true, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'modified' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array(

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -431,7 +431,7 @@ class SongsController extends AppController {
 
         // Get songs from the previous band names
         $songs = $this->Song->find('all', array(
-            'fields'        => array('Song.id', 'Song.title', 'Song.album', 'Song.band', 'Song.artist', 'Song.cover', 'Song.playtime', 'Song.track_number', 'Song.year', 'Song.disc', 'Song.genre'),
+            'fields'        => array('Song.id', 'Song.title', 'Song.album', 'Song.band', 'Song.artist', 'Song.cover', 'Song.playtime', 'Song.track_number', 'Song.year', 'Song.disc', 'Song.genre', 'Song.comment'),
             'conditions'    => array('Song.band' => $band_list)
         ));
 

--- a/app/Lib/SongManager/SongManager.php
+++ b/app/Lib/SongManager/SongManager.php
@@ -166,6 +166,11 @@ class SongManager {
             }
         }
 
+        //Comments
+        if (!empty($file_infos['comments']['comment'])) {
+            $metadata['comment'] = $file_infos['comments']['comment'][0];
+        }
+
         $metadata['source_path'] = $this->song->path;
         $result['data'] = $metadata;
         return $result;

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -300,7 +300,7 @@ msgid "Add to Up Next"
 msgstr ""
 
 #: View/Elements/add_menu.ctp:5
-#: View/Elements/add_to_playlist.ctp:43
+#: View/Elements/add_to_playlist.ctp:45
 #: View/Elements/artists_view.ctp:27;67
 #: View/Songs/album.ctp:14
 msgid "Add to..."
@@ -315,23 +315,23 @@ msgstr ""
 msgid "Select a playlist"
 msgstr ""
 
-#: View/Elements/add_to_playlist.ctp:67
+#: View/Elements/add_to_playlist.ctp:69
 msgid "Playlist Title"
 msgstr ""
 
-#: View/Elements/add_to_playlist.ctp:81
+#: View/Elements/add_to_playlist.ctp:84
 msgid "Add"
 msgstr ""
 
 #: View/Elements/admin_navbar.ctp:2
 #: View/Elements/default_navbar.ctp:2
-#: View/Settings/index.ctp:156
+#: View/Settings/index.ctp:157
 msgid "Artists"
 msgstr ""
 
 #: View/Elements/admin_navbar.ctp:3
 #: View/Elements/default_navbar.ctp:3
-#: View/Settings/index.ctp:160
+#: View/Settings/index.ctp:161
 msgid "Albums"
 msgstr ""
 
@@ -348,7 +348,7 @@ msgid "Search"
 msgstr ""
 
 #: View/Elements/admin_navbar.ctp:13
-#: View/Settings/index.ctp:118
+#: View/Settings/index.ctp:119
 msgid "Database update"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgid "Queue"
 msgstr ""
 
 #: View/Layouts/default.ctp:115
-#: View/Settings/index.ctp:164
+#: View/Settings/index.ctp:165
 msgid "Songs"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgid "Album"
 msgstr ""
 
 #: View/Playlists/index.ctp:109
-#: View/Songs/index.ctp:10
+#: View/Songs/index.ctp:11
 msgid "Duration"
 msgstr ""
 
@@ -637,71 +637,71 @@ msgstr ""
 msgid "Enable mail notifications."
 msgstr ""
 
-#: View/Settings/index.ctp:63
+#: View/Settings/index.ctp:64
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr ""
 
-#: View/Settings/index.ctp:75
+#: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr ""
 
-#: View/Settings/index.ctp:80
+#: View/Settings/index.ctp:81
 msgid "The command 'avconv' or 'ffmpeg' are not available. Sonerezh cannot convert your tracks."
 msgstr ""
 
-#: View/Settings/index.ctp:85
+#: View/Settings/index.ctp:86
 msgid "If you have heterogeneous formats in your collection, and because your browser cannot read them all, Sonerezh can convert your tracks to MP3 or OGG/Vorbis before being played. The converted songs will be stored in the \"Songs Cache\"."
 msgstr ""
 
-#: View/Settings/index.ctp:90
+#: View/Settings/index.ctp:91
 msgid "Source format"
 msgstr ""
 
-#: View/Settings/index.ctp:97
+#: View/Settings/index.ctp:98
 msgid "Destination format"
 msgstr ""
 
-#: View/Settings/index.ctp:99
+#: View/Settings/index.ctp:100
 msgid "Quality"
 msgstr ""
 
-#: View/Settings/index.ctp:111
+#: View/Settings/index.ctp:112
 msgid "Submit"
 msgstr ""
 
-#: View/Settings/index.ctp:115
+#: View/Settings/index.ctp:116
 msgid "Database management"
 msgstr ""
 
-#: View/Settings/index.ctp:121
+#: View/Settings/index.ctp:122
 msgid "Clear the cache"
 msgstr ""
 
-#: View/Settings/index.ctp:124
+#: View/Settings/index.ctp:125
 msgid "Reset the database"
 msgstr ""
 
-#: View/Settings/index.ctp:124
+#: View/Settings/index.ctp:125
 msgid "Are you sure? All your songs and playlists will disappear!"
 msgstr ""
 
-#: View/Settings/index.ctp:131
+#: View/Settings/index.ctp:132
 msgid "Support Sonerezh!"
 msgstr ""
 
-#: View/Settings/index.ctp:133
+#: View/Settings/index.ctp:134
 msgid "Help us to provide you the best music player! Make a donation."
 msgstr ""
 
-#: View/Settings/index.ctp:151
+#: View/Settings/index.ctp:152
 msgid "Sonerezh statistics"
 msgstr ""
 
-#: View/Settings/index.ctp:168
+#: View/Settings/index.ctp:169
 msgid "Thumbnails cache"
 msgstr ""
 
-#: View/Settings/index.ctp:172
+#: View/Settings/index.ctp:173
 msgid "Songs cache"
 msgstr ""
 
@@ -778,6 +778,10 @@ msgid "%s song detected "
 msgid_plural "%s songs detected "
 msgstr[0] ""
 msgstr[1] ""
+
+#: View/Songs/index.ctp:10
+msgid "Comment"
+msgstr ""
 
 #: View/Songs/search.ctp:4
 msgid "Looking for"

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Sonerezh 1.1.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2016-12-26 16:19+0100\n"
+"PO-Revision-Date: 2017-02-12 18:50+0100\n"
 "Last-Translator: Guillaume Leduc <hey@sonerezh.bzh>\n"
 "Language-Team: Sonerezh Team <hey@sonerezh.bzh>\n"
 "Language: fr\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Loco-Source-Locale: fr_FR\n"
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Target-Locale: zz_ZZ\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Poedit 1.8.11\n"
 
 #: Controller/AppController.php:83
 msgid ""
@@ -313,7 +313,7 @@ msgstr "Lire après"
 msgid "Add to Up Next"
 msgstr "Ajouter à la file d'attente"
 
-#: View/Elements/add_menu.ctp:5 View/Elements/add_to_playlist.ctp:43
+#: View/Elements/add_menu.ctp:5 View/Elements/add_to_playlist.ctp:45
 #: View/Elements/artists_view.ctp:27;67 View/Songs/album.ctp:14
 msgid "Add to..."
 msgstr "Ajouter à..."
@@ -326,21 +326,21 @@ msgstr "Télécharger"
 msgid "Select a playlist"
 msgstr "Sélectionner une liste de lecture"
 
-#: View/Elements/add_to_playlist.ctp:67
+#: View/Elements/add_to_playlist.ctp:69
 msgid "Playlist Title"
 msgstr "Titre de la liste de lecture"
 
-#: View/Elements/add_to_playlist.ctp:81
+#: View/Elements/add_to_playlist.ctp:84
 msgid "Add"
 msgstr "Ajouter"
 
 #: View/Elements/admin_navbar.ctp:2 View/Elements/default_navbar.ctp:2
-#: View/Settings/index.ctp:156
+#: View/Settings/index.ctp:157
 msgid "Artists"
 msgstr "Artistes"
 
 #: View/Elements/admin_navbar.ctp:3 View/Elements/default_navbar.ctp:3
-#: View/Settings/index.ctp:160
+#: View/Settings/index.ctp:161
 msgid "Albums"
 msgstr "Albums"
 
@@ -354,7 +354,7 @@ msgstr "Listes de lecture"
 msgid "Search"
 msgstr "Rechercher"
 
-#: View/Elements/admin_navbar.ctp:13 View/Settings/index.ctp:118
+#: View/Elements/admin_navbar.ctp:13 View/Settings/index.ctp:119
 msgid "Database update"
 msgstr "Mettre à jour la base"
 
@@ -550,7 +550,7 @@ msgstr "La file d'attente est vide."
 msgid "Queue"
 msgstr "File d'attente"
 
-#: View/Layouts/default.ctp:115 View/Settings/index.ctp:164
+#: View/Layouts/default.ctp:115 View/Settings/index.ctp:165
 msgid "Songs"
 msgstr "Pistes"
 
@@ -590,7 +590,7 @@ msgstr "Artiste"
 msgid "Album"
 msgstr "Album"
 
-#: View/Playlists/index.ctp:109 View/Songs/index.ctp:10
+#: View/Playlists/index.ctp:109 View/Songs/index.ctp:11
 msgid "Duration"
 msgstr "Durée"
 
@@ -645,17 +645,17 @@ msgstr ""
 msgid "Enable mail notifications."
 msgstr "Activer les notifications par email."
 
-#: View/Settings/index.ctp:63
+#: View/Settings/index.ctp:64
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr ""
 "Sonerezh peut vous envoyer des emails lors de certains événements (création "
 "d'utilisateurs...)"
 
-#: View/Settings/index.ctp:75
+#: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr "Conversion automatique des pistes"
 
-#: View/Settings/index.ctp:80
+#: View/Settings/index.ctp:81
 msgid ""
 "The command 'avconv' or 'ffmpeg' are not available. Sonerezh cannot convert "
 "your tracks."
@@ -663,7 +663,7 @@ msgstr ""
 "La commande 'avconv' ou 'ffmpeg' n'est pas disponible. Sonerezh ne pourra "
 "pas convertir vos pistes."
 
-#: View/Settings/index.ctp:85
+#: View/Settings/index.ctp:86
 msgid ""
 "If you have heterogeneous formats in your collection, and because your "
 "browser cannot read them all, Sonerezh can convert your tracks to MP3 or OGG/"
@@ -675,58 +675,58 @@ msgstr ""
 "MP3 ou OGG/Vorbis avant de les diffuser. Les morceaux convertis seront "
 "stockés dans le \"Cache audio\"."
 
-#: View/Settings/index.ctp:90
+#: View/Settings/index.ctp:91
 msgid "Source format"
 msgstr "Format source"
 
-#: View/Settings/index.ctp:97
+#: View/Settings/index.ctp:98
 msgid "Destination format"
 msgstr "Format de destination"
 
-#: View/Settings/index.ctp:99
+#: View/Settings/index.ctp:100
 msgid "Quality"
 msgstr "Qualité"
 
-#: View/Settings/index.ctp:111
+#: View/Settings/index.ctp:112
 msgid "Submit"
 msgstr "Enregistrer"
 
-#: View/Settings/index.ctp:115
+#: View/Settings/index.ctp:116
 msgid "Database management"
 msgstr "Gestion de la base de données"
 
-#: View/Settings/index.ctp:121
+#: View/Settings/index.ctp:122
 msgid "Clear the cache"
 msgstr "Nettoyer le cache"
 
-#: View/Settings/index.ctp:124
+#: View/Settings/index.ctp:125
 msgid "Reset the database"
 msgstr "Réinitialiser la base"
 
-#: View/Settings/index.ctp:124
+#: View/Settings/index.ctp:125
 msgid "Are you sure? All your songs and playlists will disappear!"
 msgstr ""
 "Etes-vous sûr ? Toutes vos pistes et vos listes de lecture seront "
 "supprimées !"
 
-#: View/Settings/index.ctp:131
+#: View/Settings/index.ctp:132
 msgid "Support Sonerezh!"
 msgstr "Soutenir Sonerezh!"
 
-#: View/Settings/index.ctp:133
+#: View/Settings/index.ctp:134
 msgid "Help us to provide you the best music player! Make a donation."
 msgstr ""
 "Aidez-nous à vous fournir le meilleur lecteur de musique ! Faites un don."
 
-#: View/Settings/index.ctp:151
+#: View/Settings/index.ctp:152
 msgid "Sonerezh statistics"
 msgstr "Statistiques de Sonerezh"
 
-#: View/Settings/index.ctp:168
+#: View/Settings/index.ctp:169
 msgid "Thumbnails cache"
 msgstr "Cache des miniatures"
 
-#: View/Settings/index.ctp:172
+#: View/Settings/index.ctp:173
 msgid "Songs cache"
 msgstr "Cache audio"
 
@@ -810,6 +810,10 @@ msgid "%s song detected "
 msgid_plural "%s songs detected "
 msgstr[0] "%s piste détectée "
 msgstr[1] "%s pistes détectées "
+
+#: View/Songs/index.ctp:10
+msgid "Comment"
+msgstr "Commentaire"
 
 #: View/Songs/search.ctp:4
 msgid "Looking for"

--- a/app/View/Songs/index.ctp
+++ b/app/View/Songs/index.ctp
@@ -7,6 +7,7 @@
                 <th><?php echo __('Song Title'); ?></th>
                 <th class="hidden-xs hidden-sm"><?php echo __('Artist'); ?></th>
                 <th class="visible-lg"><?php echo __('Album'); ?></th>
+                <th class="visible-lg"><?php echo __('Comment'); ?></th>
                 <th class="text-right"><?php echo __('Duration'); ?></th>
             </tr>
             </thead>
@@ -19,6 +20,7 @@
                     <td class="truncated-name"><?php echo h($song['Song']['title']); ?></td>
                     <td class="truncated-name hidden-xs hidden-sm"><?php echo h($song['Song']['band']); ?></td>
                     <td class="truncated-name visible-lg"><?php echo h($song['Song']['album']); ?></td>
+                    <td class="trucated-name visible-lg"><?php echo h($song['Song']['comment']); ?></td>
                     <td class="text-right playtime-cell">
                         <span class="song-playtime"><?php echo h($song['Song']['playtime']); ?></span>
                         <?php echo $this->element('add_menu', array('song_id' => h($song['Song']['id']), 'song_title' => h($song['Song']['title']))); ?>


### PR DESCRIPTION
Fixes #271 .

This pull request adds the "comment" tag to the list of tags scraped in SongManager (and modifies the database schema accordingly) and then displays it in the main view.

The translation files got all modified because it changed all the line numbers.

There may be a database migration script to create, but I didn't find it so I did my tests on a clean install.