### PR TITLE
Do not convert tags to HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix #354: Do not convert tags to HTML
+
 ### Changed
 
 * Make search case-insensitive

--- a/app/Lib/SongManager/SongManager.php
+++ b/app/Lib/SongManager/SongManager.php
@@ -12,6 +12,7 @@ class SongManager {
 
     function parseMetadata() {
         $getID3 = new getID3();
+        $getID3->option_tags_html = false;
         $file_infos = $getID3->analyze(($this->song->path));
         getid3_lib::CopyTagsToComments($file_infos);
 


### PR DESCRIPTION
By default, getID3 creates HTML version for all tags. In particular, it will convert the picture tag (which could be a bug). Depending on cover arts included in audio files, this feature triggers #354.
