### PR TITLE
Fix #357: APP_DIR missing in top level index.php for CAKE full path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix #354: Do not convert tags to HTML
+* Fix #357: APP_DIR missing in top level index.php for CAKE full path
 
 ### Changed
 

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ define('WWW_ROOT', ROOT . DS . APP_DIR . DS . WEBROOT_DIR . DS);
  * Full path to the directory containing "cake". Do not add trailing directory separator
  */
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-	define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
+	define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
 }
 
 require APP_DIR . DS . WEBROOT_DIR . DS . 'index.php';


### PR DESCRIPTION
The problem first described is due to missing APP_DIR in top level index.php. Depending the reference used for the sonerezh root, CakePHP will be found or not:
* using sonerezh/ will trigger the problem
* using sonerezh/app/webroot/ will not
