### PR TITLE
 Avoid CAKE_CORE_INCLUDE_PATH multiple definition

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -61,7 +61,9 @@ if (!defined('APP_DIR')) {
  * The following line differs from its sibling
  * /lib/Cake/Console/Templates/skel/webroot/index.php
  */
-define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
+if (!defined('CAKE_CORE_INCLUDE_PATH')) {
+	define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib');
+}
 
 /**
  * Editing below this line should NOT be necessary.


### PR DESCRIPTION
Making diffs with new 1.2.5 release shows that I forget this one to avoid #357 php notice. Sonerezh will work correctly without it, but will trigger some logs stating that `CAKE_CORE_INCLUDE_PATH` is already defined.