### PR TITLE
Add possibility to sort album by year

### DIFF
--- a/app/Config/Schema/sonerezh_mysql.php
+++ b/app/Config/Schema/sonerezh_mysql.php
@@ -48,6 +48,7 @@ class SonerezhMysqlSchema extends CakeSchema {
 		'convert_to' => array('type' => 'string', 'null' => false, 'default' => 'mp3', 'length' => 5, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'quality' => array('type' => 'integer', 'null' => false, 'default' => '256', 'length' => 3, 'unsigned' => true),
 		'enable_mail_notification' => array('type' => 'boolean', 'null' => false, 'default' => '0'),
+		'enable_sort_album_by_year' => array('type' => 'boolean', 'null' => false, 'default' => '0'),
 		'sync_token' => array('type' => 'integer', 'null' => true, 'default' => null, 'unsigned' => false),
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)

--- a/app/Config/Schema/sonerezh_pgsql.php
+++ b/app/Config/Schema/sonerezh_pgsql.php
@@ -48,6 +48,7 @@ class SonerezhPgsqlSchema extends CakeSchema {
 		'convert_to' => array('type' => 'string', 'null' => false, 'default' => 'mp3', 'length' => 5),
 		'quality' => array('type' => 'integer', 'null' => false, 'default' => '256'),
 		'enable_mail_notification' => array('type' => 'boolean', 'null' => false, 'default' => false),
+		'enable_sort_album_by_year' => array('type' => 'boolean', 'null' => false, 'default' => '0'),
 		'sync_token' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'indexes' => array(
 			'PRIMARY' => array('unique' => true, 'column' => 'id')

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -99,8 +99,8 @@ class AppController extends Controller {
             }
         }
 
+        $this->loadModel('Setting');
         if (!$this->request->is('ajax') && $this->Auth->user()) {
-            $this->loadModel('Setting');
             $setting = $this->Setting->find('first', array('fields' => array('sync_token')));
             $this->set('sync_token', $setting['Setting']['sync_token']);
         }

--- a/app/Controller/Component/SortComponent.php
+++ b/app/Controller/Component/SortComponent.php
@@ -15,13 +15,15 @@ class SortComponent extends Component {
      * @see https://php.net/manual/en/function.array-multisort.php
      *
      * @param array $songs Array of songs returned by the database.
+     * @param boolean $sort_album_by_year Sort albums by name if false. Sort albums by year if true.
      * @return array An array of sorted songs.
      */
-    public function sortByBand($songs) {
+    public function sortByBand($songs, $sort_album_by_year = false) {
+        $album_sort_field = $sort_album_by_year ? 'year' : 'album';
         foreach ($songs as $key => $row) {
             $s_discs = explode('/', $row['Song']['disc']);
             $s_band[$key]           = $row['Song']['band'];
-            $s_album[$key]          = $row['Song']['album'];
+            $s_album[$key]          = $row['Song'][$album_sort_field];
             $s_track_number[$key]   = $row['Song']['track_number'];
             $s_disc[$key]           = $s_discs[0];
         }

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -438,7 +438,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         // Then we can group the songs by band name, album and disc.
         $parsed = array();
@@ -512,7 +512,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         if (empty($songs)) {
             $this->Flash->info(__('Oops! The database is empty...'));
@@ -565,7 +565,7 @@ class SongsController extends AppController {
             );
 
             $this->SortComponent = $this->Components->load('Sort');
-            $songs = $this->SortComponent->sortByBand($songs);
+            $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
             $parsed = array();
             foreach ($songs as $song) {
@@ -704,7 +704,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         foreach ($songs as &$song) {
             $song['Song']['url'] = Router::url(array('controller'=>'songs', 'action'=>'download', $song['Song']['id'], 'api'=> false));
@@ -757,5 +757,15 @@ class SongsController extends AppController {
 
         $this->set('data', $songs);
         $this->set('_serialize', 'data');
+    }
+
+    private function is_enabled_sort_album_by_year() {
+        if(isset($this->Setting)) {
+            $settings = $this->Setting->find('first');
+            if(isset($settings) && isset($settings['Setting']) && isset($settings['Setting']['enable_sort_album_by_year'])) {
+                return $settings['Setting']['enable_sort_album_by_year'];
+            }
+        }
+        return false;
     }
 }

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -641,6 +641,14 @@ msgstr ""
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr ""
 
+#: View/Settings/index.ctp:57
+msgid "Enable sort albums by year."
+msgstr ""
+
+#: View/Settings/index.ctp:64
+msgid "By Default albums are sort by name. Tick this box to sort them by year."
+msgstr ""
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr ""

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -609,6 +609,15 @@ msgstr "Email-Benachrichtung aktivieren."
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr "Sonerezh kann Email-Benachrichtigungen für erstellte Nutzer verschicken, um diese zu benachrichtigen."
 
+#: View/Settings/index.ctp:57
+msgid "Enable sort albums by year."
+msgstr "Aktivieren Sie das Sortieren von Alben nach Jahr."
+
+#: View/Settings/index.ctp:64
+msgid "By Default albums are sort by name. Tick this box to sort them by year."
+msgstr ""
+"Standardmäßig werden Alben nach Namen sortiert. Aktivieren Sie dieses Kontrollkästchen, um sie nach Jahr zu sortieren."
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr "Automatische Song Konvertierung"

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -651,6 +651,16 @@ msgstr ""
 "Sonerezh peut vous envoyer des emails lors de certains événements (création "
 "d'utilisateurs...)"
 
+#: View/Settings/index.ctp:57
+msgid "Enable sort albums by year."
+msgstr "Activer le tri des albums par année."
+
+#: View/Settings/index.ctp:64
+msgid "By Default albums are sort by name. Tick this box to sort them by year."
+msgstr ""
+"Par défaut les albums sont triés par ordre alphabétique. En cochant cette "
+"case les albums seront triés par année."
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr "Conversion automatique des pistes"

--- a/app/Model/Setting.php
+++ b/app/Model/Setting.php
@@ -27,6 +27,12 @@ class Setting extends AppModel {
                 'rule'				=> array('boolean'),
                 'message'			=> 'Something went wrong!'
             )
+            ),
+        'enable_sort_album_by_year'	=> array(
+            'boolean'			=> array(
+                'rule'				=> array('boolean'),
+                'message'			=> 'Something went wrong!'
+            )
         )
     );
 

--- a/app/View/Settings/index.ctp
+++ b/app/View/Settings/index.ctp
@@ -70,6 +70,29 @@ $this->end(); ?>
                 </span>
             </small>
 
+            <?php
+            echo $this->Form->input('enable_sort_album_by_year', array(
+                'type'  => 'checkbox',
+                'label' => __('Enable sort albums by year.')
+            ));
+            ?>
+
+            <small>
+                <span class="help-block">
+                    <?php echo __('By Default albums are sort by name. Tick this box to sort them by year.'); ?>
+                </span>
+            </small>
+
+            <small>
+                <span class="help-block">
+                    <?php echo __('Sonerezh can send an email on users creation to notify them.'); ?>
+                    <?php echo $this->Html->link(
+                        '<i class="glyphicon glyphicon-question-sign"></i>',
+                        'https://www.sonerezh.bzh/docs/en/configuration.html#enable-mail-notifications',
+                        array('escape' => false, 'target' => 'blank', 'class' => 'no-ajax')
+                    ); ?>
+                </span>
+            </small>
 
             <div class="panel <?php echo $avconv ? 'panel-default' : 'panel-danger'; ?>">
                 <div class="panel-heading">


### PR DESCRIPTION
As I wrote in the PR title, this is a little piece of code to add possibility to sort albums (in artist and search view only) by year and no more by name.

By default nothing will change. The sort order will be changed only if we tick a checkbox on the settings page.

Do manage this feature I added a new setting value, stored in the database as a new column. So to use this feature it's mandatory to add the column to the table settings. It's possible to make it by hand (I can add some doc to give every user an SQL request to edit the database), or we can use Migrations plugin : https://book.cakephp.org/migrations/2.x/en/index.html#adding-columns-to-an-existing-table. Tell me what do you think is the better choise.

By the way, if the column was not added nothing will be broken. All will working as usual.

I think it fix initial request of this issue: #125.

Can you give me your opinion about this feature? :)