### PR TITLE
Add a setting parameter to define how many recent added albums lines should be displayed

### DIFF
--- a/app/Config/Schema/sonerezh_mysql.php
+++ b/app/Config/Schema/sonerezh_mysql.php
@@ -48,6 +48,7 @@ class SonerezhMysqlSchema extends CakeSchema {
 		'convert_to' => array('type' => 'string', 'null' => false, 'default' => 'mp3', 'length' => 5, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'quality' => array('type' => 'integer', 'null' => false, 'default' => '256', 'length' => 3, 'unsigned' => true),
 		'enable_mail_notification' => array('type' => 'boolean', 'null' => false, 'default' => '0'),
+		'nb_latest_albums_lines' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 3, 'unsigned' => true),
 		'sync_token' => array('type' => 'integer', 'null' => true, 'default' => null, 'unsigned' => false),
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)

--- a/app/Config/Schema/sonerezh_pgsql.php
+++ b/app/Config/Schema/sonerezh_pgsql.php
@@ -48,6 +48,7 @@ class SonerezhPgsqlSchema extends CakeSchema {
 		'convert_to' => array('type' => 'string', 'null' => false, 'default' => 'mp3', 'length' => 5),
 		'quality' => array('type' => 'integer', 'null' => false, 'default' => '256'),
 		'enable_mail_notification' => array('type' => 'boolean', 'null' => false, 'default' => false),
+		'nb_latest_albums_lines' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 3, 'unsigned' => true),
 		'sync_token' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'indexes' => array(
 			'PRIMARY' => array('unique' => true, 'column' => 'id')

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -99,8 +99,8 @@ class AppController extends Controller {
             }
         }
 
+        $this->loadModel('Setting');
         if (!$this->request->is('ajax') && $this->Auth->user()) {
-            $this->loadModel('Setting');
             $setting = $this->Setting->find('first', array('fields' => array('sync_token')));
             $this->set('sync_token', $setting['Setting']['sync_token']);
         }

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -337,12 +337,23 @@ class SongsController extends AppController {
         $this->Song->virtualFields['cover'] = 'MIN(Song.cover)';
 
         if ($page == 1) {
-            $latests = $this->Song->find('all', array(
-                'fields' => array('Song.band', 'Song.album', 'cover'),
-                'group' => array('Song.album', 'Song.band'),
-                'order' => 'MAX(Song.created) DESC',
-                'limit' => 6
-            ));
+            $nb_latest_albums = 6;
+            if(isset($this->Setting)) {
+                $settings = $this->Setting->find('first');
+                if(isset($settings) && isset($settings['Setting']) && isset($settings['Setting']['nb_latest_albums_lines'])) {
+                    $nb_latest_albums = 6 * $settings['Setting']['nb_latest_albums_lines'];
+                }
+            }
+            if($nb_latest_albums > 0) {
+                $latests = $this->Song->find('all', array(
+                    'fields' => array('Song.band', 'Song.album', 'cover'),
+                    'group' => array('Song.album', 'Song.band'),
+                    'order' => 'MAX(Song.created) DESC',
+                    'limit' => $nb_latest_albums
+                ));
+            } else {
+                $latests = [];
+            }
         }
 
         $this->Paginator->settings = array(
@@ -438,7 +449,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         // Then we can group the songs by band name, album and disc.
         $parsed = array();
@@ -512,7 +523,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         if (empty($songs)) {
             $this->Flash->info(__('Oops! The database is empty...'));
@@ -565,7 +576,7 @@ class SongsController extends AppController {
             );
 
             $this->SortComponent = $this->Components->load('Sort');
-            $songs = $this->SortComponent->sortByBand($songs);
+            $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
             $parsed = array();
             foreach ($songs as $song) {
@@ -704,7 +715,7 @@ class SongsController extends AppController {
         ));
 
         $this->SortComponent = $this->Components->load('Sort');
-        $songs = $this->SortComponent->sortByBand($songs);
+        $songs = $this->SortComponent->sortByBand($songs, $this->is_enabled_sort_album_by_year());
 
         foreach ($songs as &$song) {
             $song['Song']['url'] = Router::url(array('controller'=>'songs', 'action'=>'download', $song['Song']['id'], 'api'=> false));
@@ -757,5 +768,15 @@ class SongsController extends AppController {
 
         $this->set('data', $songs);
         $this->set('_serialize', 'data');
+    }
+
+    private function is_enabled_sort_album_by_year() {
+        if(isset($this->Setting)) {
+            $settings = $this->Setting->find('first');
+            if(isset($settings) && isset($settings['Setting']) && isset($settings['Setting']['enable_sort_album_by_year'])) {
+                return $settings['Setting']['enable_sort_album_by_year'];
+            }
+        }
+        return false;
     }
 }

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -641,6 +641,14 @@ msgstr ""
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr ""
 
+#: View/Settings/index.ctp:57
+msgid "Number of line to use to display latest albums."
+msgstr ""
+
+#: View/Settings/index.ctp:64
+msgid "By Default only one line of six albums is displayed. Note: it will change only desktop version, not mobile version."
+msgstr ""
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr ""

--- a/app/Locale/deu/LC_MESSAGES/default.po
+++ b/app/Locale/deu/LC_MESSAGES/default.po
@@ -609,6 +609,15 @@ msgstr "Email-Benachrichtung aktivieren."
 msgid "Sonerezh can send an email on users creation to notify them."
 msgstr "Sonerezh kann Email-Benachrichtigungen für erstellte Nutzer verschicken, um diese zu benachrichtigen."
 
+#: View/Settings/index.ctp:57
+msgid "Number of line to use to display latest albums."
+msgstr "Nummer der Zeile, in der die neuesten Alben angezeigt werden sollen."
+
+#: View/Settings/index.ctp:64
+msgid "By Default only one line of six albums is displayed. Note: it will change only desktop version, not mobile version."
+msgstr ""
+"Standardmäßig wird nur eine Zeile mit sechs Alben angezeigt. Hinweis: Es wird nur die Desktop-Version geändert, nicht die mobile Version."
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr "Automatische Song Konvertierung"

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -651,6 +651,15 @@ msgstr ""
 "Sonerezh peut vous envoyer des emails lors de certains événements (création "
 "d'utilisateurs...)"
 
+#: View/Settings/index.ctp:57
+msgid "Number of line to use to display latest albums."
+msgstr "Nombre de ligne à utiliser pour afficher les derniers albums."
+
+#: View/Settings/index.ctp:64
+msgid "By Default only one line of six albums is displayed. Note: it will change only desktop version, not mobile version."
+msgstr ""
+"Par défaut, une seule ligne de six albums sera affichée. Note: ce paramètre ne changera que l'affichage pc, pas la version mobile."
+
 #: View/Settings/index.ctp:76
 msgid "Automatic tracks conversion"
 msgstr "Conversion automatique des pistes"

--- a/app/Model/Setting.php
+++ b/app/Model/Setting.php
@@ -27,6 +27,12 @@ class Setting extends AppModel {
                 'rule'				=> array('boolean'),
                 'message'			=> 'Something went wrong!'
             )
+            ),
+        'nb_latest_albums_lines'	=> array(
+            'integer'			=> array(
+                'rule'				=> array('integer'),
+                'message'			=> 'Something went wrong!'
+            )
         )
     );
 

--- a/app/View/Settings/index.ctp
+++ b/app/View/Settings/index.ctp
@@ -70,6 +70,18 @@ $this->end(); ?>
                 </span>
             </small>
 
+            <?php
+            echo $this->Form->input('nb_latest_albums_lines', array(
+                'type'  => 'number',
+                'label' => __('Number of line to use to display latest albums.')
+            ));
+            ?>
+
+            <small>
+                <span class="help-block">
+                    <?php echo __('By Default only one line of six albums is displayed. Note: it will change only desktop version, not mobile version.'); ?>
+                </span>
+            </small>
 
             <div class="panel <?php echo $avconv ? 'panel-default' : 'panel-danger'; ?>">
                 <div class="panel-heading">


### PR DESCRIPTION
My objective here is to add an entry in the setting page to let me display 2 lines of recently added album. I often add full discography or lot of albums to my Sonerezh, so I can see in this section all albums I just add.

This setting will now let user to decide how many line to display for recently added albums. 
It will only work for desktop view. I let the bootstrap style cut after 3-5 albums when the screen become smaller.

Like I made in PR #377, I made the same settings initialization fix (to ensure the settings are loaded when I now using it in the song controller).