### PR TITLE
display randomly-selected albums

### DIFF
--- a/app/Config/Schema/sonerezh_mysql.php
+++ b/app/Config/Schema/sonerezh_mysql.php
@@ -48,6 +48,8 @@ class SonerezhMysqlSchema extends CakeSchema {
 		'convert_to' => array('type' => 'string', 'null' => false, 'default' => 'mp3', 'length' => 5, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'quality' => array('type' => 'integer', 'null' => false, 'default' => '256', 'length' => 3, 'unsigned' => true),
 		'enable_mail_notification' => array('type' => 'boolean', 'null' => false, 'default' => '0'),
+		'enable_random' => array('type' => 'boolean', 'null' => false, 'default' => '1'),
+		'enable_recent' => array('type' => 'boolean', 'null' => false, 'default' => '1'),
 		'sync_token' => array('type' => 'integer', 'null' => true, 'default' => null, 'unsigned' => false),
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -330,9 +330,16 @@ class SongsController extends AppController {
         ));
 
         $latests = array();
+        $rands = array();
         // Is this the first page requested?
         $page = isset($this->request->params['named']['page']) ? $this->request->params['named']['page'] : 1;
         $db = $this->Song->getDataSource();
+
+        if ($db->config['datasource'] == 'Database/Mysql') {
+            $random_order_by_method = 'RAND()';
+        } else {
+            $random_order_by_method = 'RANDOM()';
+        }
 
         $this->Song->virtualFields['cover'] = 'MIN(Song.cover)';
 
@@ -341,6 +348,12 @@ class SongsController extends AppController {
                 'fields' => array('Song.band', 'Song.album', 'cover'),
                 'group' => array('Song.album', 'Song.band'),
                 'order' => 'MAX(Song.created) DESC',
+                'limit' => 6
+            ));
+            $rands = $this->Song->find('all', array(
+                'fields' => array('Song.id', 'Song.band', 'Song.album', 'Song.cover'),
+                'group' => 'Song.album',
+                'order' => $random_order_by_method,
                 'limit' => 6
             ));
         }
@@ -364,11 +377,15 @@ class SongsController extends AppController {
             $latest['Song']['cover'] = empty($latest['Song']['cover']) ? "no-cover.png" : THUMBNAILS_DIR.'/'.$latest['Song']['cover'];
         }
 
+        foreach ($rands as &$r) {
+            $r['Song']['cover'] = empty($r['Song']['cover']) ? "no-cover.png" : THUMBNAILS_DIR.'/'.$r['Song']['cover'];
+        }
+
         if (empty($songs)) {
             $this->Flash->info(__('Oops! The database is empty...'));
         }
 
-        $this->set(compact('songs', 'playlists', 'latests'));
+        $this->set(compact('songs', 'playlists', 'latests', 'rands'));
     }
 
     /**

--- a/app/Locale/default.pot
+++ b/app/Locale/default.pot
@@ -717,6 +717,10 @@ msgstr ""
 msgid "All albums"
 msgstr ""
 
+#: View/Songs/albums.ctp:48
+msgid "Random albums"
+msgstr ""
+
 #: View/Songs/albums.ctp:52
 msgid "Sort by album"
 msgstr ""

--- a/app/Locale/fra/LC_MESSAGES/default.po
+++ b/app/Locale/fra/LC_MESSAGES/default.po
@@ -742,6 +742,10 @@ msgstr "Ajoutés récemment"
 msgid "All albums"
 msgstr "Albums"
 
+#: View/Songs/albums.ctp:48
+msgid "Random albums"
+msgstr "Au hasard"
+
 #: View/Songs/albums.ctp:52
 msgid "Sort by album"
 msgstr "Trier par album"

--- a/app/Model/Setting.php
+++ b/app/Model/Setting.php
@@ -27,6 +27,18 @@ class Setting extends AppModel {
                 'rule'				=> array('boolean'),
                 'message'			=> 'Something went wrong!'
             )
+        ),
+        'enable_random'        => array(
+            'boolean'                  => array(
+                'rule'                         => array('boolean'),
+                'message'                      => 'Something went wrong!'
+            )
+        ),
+        'enable_recent'        => array(
+            'boolean'                  => array(
+                'rule'                         => array('boolean'),
+                'message'                      => 'Something went wrong!'
+            )
         )
     );
 

--- a/app/View/Settings/index.ctp
+++ b/app/View/Settings/index.ctp
@@ -70,6 +70,16 @@ $this->end(); ?>
                 </span>
             </small>
 
+            <?php
+            echo $this->Form->input('enable_random', array(
+                'type'  => 'checkbox',
+                'label' => __('Enable display of random albums.')
+            ));
+            echo $this->Form->input('enable_recent', array(
+                'type'  => 'checkbox',
+                'label' => __('Enable display of recently added albums.')
+            ));
+            ?>
 
             <div class="panel <?php echo $avconv ? 'panel-default' : 'panel-danger'; ?>">
                 <div class="panel-heading">

--- a/app/View/Songs/albums.ctp
+++ b/app/View/Songs/albums.ctp
@@ -3,46 +3,99 @@ echo $this->Html->script('albums');
 $this->end(); ?>
 
 <div class="col-lg-12" data-scroll-container="true" data-view="albums">
-    <?php if (!empty($latests) && $this->Paginator->current('Song') == 1): ?>
-        <h3><?php echo __('Recently added'); ?></h3>
-        <?php $i = 1; ?>
-        <?php $hidden = ''; ?>
-        <?php foreach ($latests as $album): ?>
-            <?php if ($i == 4) {
-                $hidden = 'hidden-xs';
-            } elseif ($i >= 5) {
-                    $hidden = 'hidden-sm hidden-xs';
-            } ?>
-            <div class="col-md-2 col-sm-3 col-xs-4 action-expend <?php echo $hidden; ?>" data-band="<?php echo h($album['Song']['band']); ?>" data-album="<?php echo h($album['Song']['album']); ?>" data-scroll-content="true">
-                <?php echo $this->Image->lazyload($this->Image->resizedPath($album['Song']['cover'], 220, 220), array('class' => 'img-responsive cover lzld', 'style' => 'cursor: pointer;')); ?>
-                <h4 class="truncated-name" title="<?php echo h($album['Song']['album']); ?>">
-                    <?php echo h($album['Song']['album']); ?>
-                    <small>
-                        <br /><?php echo h($album['Song']['band']); ?>
-                    </small>
-                </h4>
-            </div>
-            <?php
-            $clear = false;
-            if ($i % 6 == 0) {
-                $clear = "visible-lg visible-md visible-xs";
-                if ( $i % 4 == 0) {
-                    $clear .= " visible-sm";
-                }
-            } elseif ($i % 4 == 0) {
-                $clear = "visible-sm";
-            } elseif ($i % 3 == 0) {
-                $clear = "visible-xs";
-            }
-            ?>
-            <?php if ($clear !== false): ?>
-                <div class="clearfix <?php echo $clear; ?>" data-scroll-content="true"></div>
-            <?php endif;
-            $i++; ?>
-        <?php endforeach; ?>
-        <div class="clearfix"></div>
-        <hr />
+    <?php
+    $setting = ClassRegistry::init('Setting');
+    $settings = $setting->find('first', array('fields' => array('Setting.enable_random')));
+    $random_enabled = $settings['Setting']['enable_random'];
+    $settings = $setting->find('first', array('fields' => array('Setting.enable_recent')));
+    $recent_enabled = $settings['Setting']['enable_recent'];
+    ?>
+
+    <?php if ($recent_enabled): ?>
+        <?php if (!empty($latests) && $this->Paginator->current('Song') == 1): ?>
+            <h3><?php echo __('Recently added'); ?></h3>
+            <?php $i = 1; ?>
+            <?php $hidden = ''; ?>
+            <?php foreach ($latests as $album): ?>
+                <?php if ($i == 4) {
+                    $hidden = 'hidden-xs';
+                } elseif ($i >= 5) {
+                        $hidden = 'hidden-sm hidden-xs';
+                } ?>
+                <div class="col-md-2 col-sm-3 col-xs-4 action-expend <?php echo $hidden; ?>" data-band="<?php echo h($album['Song']['band']); ?>" data-album="<?php echo h($album['Song']['album']); ?>" data-scroll-content="true">
+                    <?php echo $this->Image->lazyload($this->Image->resizedPath($album['Song']['cover'], 220, 220), array('class' => 'img-responsive cover lzld', 'style' => 'cursor: pointer;')); ?>
+                    <h4 class="truncated-name" title="<?php echo h($album['Song']['album']); ?>">
+                        <?php echo h($album['Song']['album']); ?>
+                        <small>
+                            <br /><?php echo h($album['Song']['band']); ?>
+                        </small>
+                    </h4>
+                </div>
+                <?php
+                $clear = false;
+                if ($i % 6 == 0) {
+                    $clear = "visible-lg visible-md visible-xs";
+                    if ( $i % 4 == 0) {
+                        $clear .= " visible-sm";
+                    }
+                } elseif ($i % 4 == 0) {
+                    $clear = "visible-sm";
+                } elseif ($i % 3 == 0) {
+                    $clear = "visible-xs";
+                 }
+                ?>
+                <?php if ($clear !== false): ?>
+                    <div class="clearfix <?php echo $clear; ?>" data-scroll-content="true"></div>
+                <?php endif;
+                $i++; ?>
+            <?php endforeach; ?>
+            <div class="clearfix"></div>
+            <hr />
+        <?php endif; ?>
     <?php endif; ?>
+
+    <?php if ($random_enabled): ?>
+        <?php if (!empty($rands) && $this->Paginator->current('Song') == 1): ?>
+            <h3><?php echo __('Random albums'); ?></h3>
+            <?php $i = 1; ?>
+            <?php $hidden = ''; ?>
+            <?php foreach ($rands as $album): ?>
+                <?php if ($i == 4) {
+                    $hidden = 'hidden-xs';
+                } elseif ($i >= 5) {
+                        $hidden = 'hidden-sm hidden-xs';
+                } ?>
+                <div class="col-md-2 col-sm-3 col-xs-4 action-expend <?php echo $hidden; ?>" data-band="<?php echo h($album['Song']['band']); ?>" data-album="<?php echo h($album['Song']['album']); ?>" data-scroll-content="true">
+                    <?php echo $this->Image->lazyload($this->Image->resizedPath($album['Song']['cover'], 220, 220), array('class' => 'img-responsive cover lzld', 'style' => 'cursor: pointer;')); ?>
+                    <h4 class="truncated-name" title="<?php echo h($album['Song']['album']); ?>">
+                        <?php echo h($album['Song']['album']); ?>
+                        <small>
+                            <br /><?php echo h($album['Song']['band']); ?>
+                        </small>
+                    </h4>
+                </div>
+                <?php
+                $clear = false;
+                if ($i % 6 == 0) {
+                    $clear = "visible-lg visible-md visible-xs";
+                    if ( $i % 4 == 0) {
+                        $clear .= " visible-sm";
+                    }
+                } elseif ($i % 4 == 0) {
+                    $clear = "visible-sm";
+                } elseif ($i % 3 == 0) {
+                    $clear = "visible-xs";
+                }
+                ?>
+                <?php if ($clear !== false): ?>
+                    <div class="clearfix <?php echo $clear; ?>" data-scroll-content="true"></div>
+                <?php endif;
+                $i++; ?>
+            <?php endforeach; ?>
+            <div class="clearfix"></div>
+            <hr />
+        <?php endif; ?>
+     <?php endif; ?>
 
     <?php if (!empty($songs)): ?>
         <h3>


### PR DESCRIPTION
Add two new settings to control the display of the "albums" page. It makes the row of recently-added albums optional, and also adds a new optional row displaying a random selection of albums.

This PR fixes https://github.com/Sonerezh/sonerezh/issues/299

This PR is basically https://github.com/Sonerezh/sonerezh/pull/298 but starting from release 1.2.6.